### PR TITLE
DayCellのアスペクト比調整 #20

### DIFF
--- a/src/components/MonthlyCalendar/DayCell/index.module.scss
+++ b/src/components/MonthlyCalendar/DayCell/index.module.scss
@@ -1,6 +1,9 @@
 @use "variables";
 
 .day-cell {
+  // カレンダーは5x7なので1/5=20%
+  // FIXME: 上位コンポーネントについての知識を持ってしまっている
+  height: 20%;
   text-align: center;
   vertical-align: top;
   border: variables.$border-width solid variables.$border-color;


### PR DESCRIPTION
アスペクト比は従来通り`table`に指定した。

`td`の`height`が均等割りにならないのは仕様なので、均等になるよう指定する必要がある。
今回は5行なので`20%`としたが、一般的な書き方ができるとより良い。